### PR TITLE
Write version to boot/version.txt

### DIFF
--- a/generate_image_file.sh
+++ b/generate_image_file.sh
@@ -1,9 +1,17 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+
+# Determine the version
+# If we're on a tagged commit, then this is just the tag
+# Otherwise it's the last tag, then the number of commits since that tag, then the current hash
+# Finally, if there are uncommitted changes, -dirty is appended
+# If there are no git tags, fall back to just the short hash
+VERSION=$(git describe --tags --dirty || git rev-parse --short HEAD)
+
 ROOTDIR="."
 UBOOTBIN="${ROOTDIR}/boot/misc/u-boot-bins/u-boot-v90_q90_pocketgo.bin"
-OUTFILE="${ROOTDIR}/cfw-dev-$(date '+%Y%m%d').img"
+OUTFILE="${ROOTDIR}/cfw-${VERSION}.img"
 
 ## helpers
 BOLDRED='\e[1;31m'
@@ -81,6 +89,8 @@ $BB umount "${TEMPMOUNT}"
 msg "Copying over boot files ..."
 $BB mount "${LOOPDEV}p1" "${TEMPMOUNT}"
 $BB cp -Lr "${BOOTFILES}"/* "${TEMPMOUNT}"
+msg "Writing $VERSION to /boot/version.txt..."
+echo "$VERSION" > "${TEMPMOUNT}/version.txt"
 $BB umount "${TEMPMOUNT}"
 msg "Copying over main files ..."
 $BB mount "${LOOPDEV}p4" "${TEMPMOUNT}"


### PR DESCRIPTION
Once the repo has at least one git tag, the version will from the command [`git describe --tags --dirty`](https://git-scm.com/docs/git-describe). For example if you've made a `1.4.0` tag, it will do the following:
* When building the commit that matches the tag `1.4.0`, then the version will be simply `1.4.0`.
* If there have been 3 commits since the `1.4.0` tag, and the short hash of the current commit is `abc123`, the version will be `1.4.0-3-abc123`
* If there are uncommitted changes, then it's one of the above + `-dirty`, e.g. `1.4.0-dirty` or `1.4.0-3-abc123-dirty`

However, until the repo gets at least one tag, it will uses [`git rev-parse --short HEAD`](https://git-scm.com/docs/git-rev-parse) as a fallback to just get a short hash of the current commit (without any dirty-checking).

The version is written to `boot/version.txt` when the image is built. This fill will then be read by GmenuNX to report the value in the about menu. (Sibling GmenuNX PR at https://github.com/MiyooCFW/gmenunx/pull/14)

(I'd like to also use it in u-boot, but that's blocked on either finding or recreating u-boot source code with a working video driver.)