### PR TITLE
Accept version from environment property

### DIFF
--- a/generate_image_file.sh
+++ b/generate_image_file.sh
@@ -2,12 +2,12 @@
 set -euo pipefail
 
 
-# Determine the version
+# Determine the version if it's not set
 # If we're on a tagged commit, then this is just the tag
 # Otherwise it's the last tag, then the number of commits since that tag, then the current hash
 # Finally, if there are uncommitted changes, -dirty is appended
 # If there are no git tags, fall back to just the short hash
-VERSION=$(git describe --tags --dirty || git rev-parse --short HEAD)
+VERSION="${VERSION:-$(git describe --tags --dirty || git rev-parse --short HEAD)}"
 
 ROOTDIR="."
 UBOOTBIN="${ROOTDIR}/boot/misc/u-boot-bins/u-boot-v90_q90_pocketgo.bin"


### PR DESCRIPTION
This is so that we can use the hash/tag/etc from the main repo when doing a nightly build.