### PR TITLE
fix u-boot on v90_v2

### DIFF
--- a/boot/variants/v90_v2/firstboot.custom.sh
+++ b/boot/variants/v90_v2/firstboot.custom.sh
@@ -1,2 +1,2 @@
 echo "Writing U-BOOT - DO NOT TURN OFF THE HANDHELD!!!"
-dd if=../../misc/u-boot-bins/u-boot-v90_v2.bin of=/dev/mmcblk0 bs=1024 seek=8
+dd if=../../misc/u-boot-bins/u-boot-v90_q90_pocketgo.bin of=/dev/mmcblk0 bs=1024 seek=8


### PR DESCRIPTION
for now we use the same u-boot for v90_v2 variant as in pocketgo & q90 - see: [miyoo_pocketgo_defconfig](https://github.com/MiyooCFW/uboot/blob/master/configs/miyoo_pocketgo_defconfig)